### PR TITLE
Fix some miscapitalized references to 'FileSystem'

### DIFF
--- a/docs/collections.md
+++ b/docs/collections.md
@@ -93,7 +93,7 @@ class RoboFile extends \Robo\Tasks
 
         // If all of the tasks succeed, then rename the temporary directory
         // to its final name.
-        $this->taskFileSystemStack()
+        $this->taskFilesystemStack()
           ->rename($work, 'destination')
           ->addToCollection($collection);
         

--- a/docs/tasks/Filesystem.md
+++ b/docs/tasks/Filesystem.md
@@ -1,4 +1,4 @@
-# FileSystem Tasks
+# Filesystem Tasks
 
 ## CleanDir
 
@@ -70,12 +70,12 @@ $this->_deleteDir(['tmp', 'log']);
 ## FilesystemStack
 
 
-Wrapper for [Symfony FileSystem](http://symfony.com/doc/current/components/filesystem.html) Component.
+Wrapper for [Symfony Filesystem](http://symfony.com/doc/current/components/filesystem.html) Component.
 Comands are executed in stack and can be stopped on first fail with `stopOnFail` option.
 
 ``` php
 <?php
-$this->taskFileSystemStack()
+$this->taskFilesystemStack()
      ->mkdir('logs')
      ->touch('logs/.gitignore')
      ->chgrp('www', 'www-data')
@@ -222,7 +222,7 @@ Move the directory to another location to prevent its deletion.
 // Note that in this example, everything is deleted at
 // the end of $collection->run().
 $tmpPath = $this->taskTmpDir()->addToCollection($collection)->getPath();
-$this->taskFileSystemStack()
+$this->taskFilesystemStack()
           ->mkdir("$tmpPath/log")
           ->touch("$tmpPath/log/error.txt")
           ->addToCollection($collection);

--- a/tests/_helpers/CliHelper.php
+++ b/tests/_helpers/CliHelper.php
@@ -25,7 +25,7 @@ class CliHelper extends \Codeception\Module implements ContainerAwareInterface
         taskGenTask as public;
         taskDeleteDir as public;
         taskFlattenDir as public;
-        taskFileSystemStack as public;
+        taskFilesystemStack as public;
         taskTmpDir as public;
         _copyDir as public shortcutCopyDir;
         _mirrorDir as public shortcutMirrorDir;

--- a/tests/cli/CollectionCest.php
+++ b/tests/cli/CollectionCest.php
@@ -13,7 +13,7 @@ class CollectionCest
     {
         $I->getContainer()->addServiceProvider(\Robo\Collection\Collection::getCollectionServices());
         $I->getContainer()->addServiceProvider(\Robo\Task\File\loadTasks::getFileServices());
-        $I->getContainer()->addServiceProvider(\Robo\Task\FileSystem\loadTasks::getFileSystemServices());
+        $I->getContainer()->addServiceProvider(\Robo\Task\Filesystem\loadTasks::getFilesystemServices());
 
         $I->amInPath(codecept_data_dir().'sandbox');
     }
@@ -24,12 +24,12 @@ class CollectionCest
         $collection = $I->getContainer()->get('collection');
 
         // Set up a filesystem stack, but use addToCollection() to defer execution
-        $I->taskFileSystemStack()
+        $I->taskFilesystemStack()
             ->mkdir('log')
             ->touch('log/error.txt')
             ->addToCollection($collection);
 
-        // FileSystemStack has not run yet, so file should not be found.
+        // FilesystemStack has not run yet, so file should not be found.
         $I->dontSeeFileFound('log/error.txt');
 
         // Run the task collection; now the files should be present
@@ -60,7 +60,7 @@ class CollectionCest
         $I->seeDirFound($tmpPath);
 
         // Set up a filesystem stack, but use addToCollection() to defer execution
-        $I->taskFileSystemStack()
+        $I->taskFilesystemStack()
             ->mkdir("$tmpPath/tmp")
             ->touch("$tmpPath/tmp/error.txt")
             ->rename("$tmpPath/tmp", "$tmpPath/log")
@@ -70,7 +70,7 @@ class CollectionCest
         $I->taskCopyDir([$tmpPath => 'copied'])
             ->addToCollection($collection);
 
-        // FileSystemStack has not run yet, so no files should be found.
+        // FilesystemStack has not run yet, so no files should be found.
         $I->dontSeeFileFound("$tmpPath/tmp/error.txt");
         $I->dontSeeFileFound("$tmpPath/log/error.txt");
         $I->dontSeeFileFound('copied/log/error.txt');
@@ -105,7 +105,7 @@ class CollectionCest
         // Set up a filesystem stack, but use addToCollection() to defer execution.
         // Note that since we used 'cwd()' above, the relative file paths
         // used below will be inside the temporary directory.
-        $I->taskFileSystemStack()
+        $I->taskFilesystemStack()
             ->mkdir("log")
             ->touch("log/error.txt")
             ->addToCollection($collection);
@@ -114,7 +114,7 @@ class CollectionCest
         $I->taskCopyDir(['log' => "$cwd/copied2"])
             ->addToCollection($collection);
 
-        // FileSystemStack has not run yet, so no files should be found.
+        // FilesystemStack has not run yet, so no files should be found.
         $I->dontSeeFileFound("$tmpPath/log/error.txt");
         $I->dontSeeFileFound('$cwd/copied2/log/error.txt');
 
@@ -149,11 +149,11 @@ class CollectionCest
             ->getPath();
 
         // Copy our tmp directory to a location that is not transient
-        $I->taskFileSystemStack()
+        $I->taskFilesystemStack()
             ->copy($tmpPath, 'copied.txt')
             ->addToCollection($collection);
 
-        // FileSystemStack has not run yet, so no files should be found.
+        // FilesystemStack has not run yet, so no files should be found.
         $I->dontSeeFileFound("$tmpPath");
         $I->dontSeeFileFound('copied.txt');
 
@@ -185,7 +185,7 @@ class CollectionCest
         // via the add() method.
         $result = $collection->addTaskList(
             [
-                $I->taskFileSystemStack()->mkdir("$tmpPath/log")->touch("$tmpPath/log/error.txt"),
+                $I->taskFilesystemStack()->mkdir("$tmpPath/log")->touch("$tmpPath/log/error.txt"),
                 $I->taskCopyDir([$tmpPath => 'copied3']),
             ]
         )->run();

--- a/tests/cli/FilesystemStackCest.php
+++ b/tests/cli/FilesystemStackCest.php
@@ -1,16 +1,16 @@
 <?php
 
-class FileSystemStackCest
+class FilesystemStackCest
 {
     public function _before(CliGuy $I)
     {
-        $I->getContainer()->addServiceProvider(\Robo\Task\FileSystem\loadTasks::getFileSystemServices());
+        $I->getContainer()->addServiceProvider(\Robo\Task\Filesystem\loadTasks::getFilesystemServices());
         $I->amInPath(codecept_data_dir().'sandbox');
     }
 
     public function toCreateDir(CliGuy $I)
     {
-        $I->taskFileSystemStack()
+        $I->taskFilesystemStack()
             ->mkdir('log')
             ->touch('log/error.txt')
             ->run();
@@ -19,7 +19,7 @@ class FileSystemStackCest
 
     public function toDeleteFile(CliGuy $I)
     {
-        $I->taskFileSystemStack()
+        $I->taskFilesystemStack()
             ->stopOnFail()
             ->remove('a.txt')
             ->run();
@@ -28,7 +28,7 @@ class FileSystemStackCest
 
     public function toTestCrossVolumeRename(CliGuy $I)
     {
-        $fsStack = $I->taskFileSystemStack()
+        $fsStack = $I->taskFilesystemStack()
             ->mkdir('log')
             ->touch('log/error.txt');
         $fsStack->run();
@@ -39,7 +39,7 @@ class FileSystemStackCest
         // We will get a reference to it via reflection, set
         // the reflected method object to public, and then
         // call it via reflection.
-        $class = new ReflectionClass('\Robo\Task\FileSystem\FileSystemStack');
+        $class = new ReflectionClass('\Robo\Task\Filesystem\FilesystemStack');
         $method = $class->getMethod('crossVolumeRename');
         $method->setAccessible(true);
         $method->invokeArgs($fsStack, ['log', 'logfiles']);


### PR DESCRIPTION
Should be 'Filesystem' everywhere, for consistencey with Symfony components.

This change was made some time back, but a few instances of 'FileSystem' were missed.