### PR TITLE
Fixed robo.phar to not contain dev dependencies.

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -238,10 +238,12 @@ class RoboFile extends \Robo\Tasks
     {
         $collection = $this->collection();
 
+        // Make sure to remove dev files before finding the files to pack into
+        // the phar.
         $this->taskComposerInstall()
             ->noDev()
             ->printed(false)
-            ->addToCollection($collection);
+            ->run();
 
         $packer = $this->taskPackPhar('robo.phar');
         $files = Finder::create()->ignoreVCS(true)
@@ -262,10 +264,6 @@ class RoboFile extends \Robo\Tasks
         }
         $packer->addFile('robo', 'robo')
             ->executable('robo')
-            ->addToCollection($collection);
-
-        $this->taskComposerInstall()
-            ->printed(false)
             ->addToCollection($collection);
 
         return $collection->run();


### PR DESCRIPTION
I noticed that robo.phar is really big (12MB!!). Researching this it quickly turned out that it includes the dev dependencies. Problem is that the previous code had a bug, which lets it pick up currently install dev-dependencies when packing the phar. The PR fixes this, what results in a way smaller phar: ~1.5MB.