### PR TITLE
Do not document common methods of BaseTask in all of the tasks.

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -183,7 +183,23 @@ class RoboFile extends \Robo\Tasks
                     if ($m->isConstructor() || $m->isDestructor() || $m->isStatic()) {
                         return false;
                     }
-                    return !in_array($m->name, ['run', '', '__call', 'getCommand', 'getPrinted']) && $m->isPublic(); // methods are not documented
+                    $undocumentedMethods =
+                    [
+                        '',
+                        'run',
+                        '__call',
+                        'inflect',
+                        'injectDependencies',
+                        'getCommand',
+                        'getPrinted',
+                        'getConfig',
+                        'setConfig',
+                        'logger',
+                        'setLogger',
+                        'setProgressIndicator',
+                        'progressIndicatorSteps',
+                    ];
+                    return !in_array($m->name, $undocumentedMethods) && $m->isPublic(); // methods are not documented
                 }
             )->processClassSignature(
                 function ($c) {


### PR DESCRIPTION
This increases the blacklist of methods to not include by rote in the documentation of every Task that extends BaseTask.

Run `./robo docs` followed by `git diff` to see the effect. I didn't include the generated files in this  PR to avoid conflicts with #393.