### PR TITLE
Add a --supress-messages global option to turn off all task io messages.

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -26,6 +26,10 @@ class Application extends SymfonyApplication implements ContainerAwareInterface
             ->addOption(
                 new InputOption('--progress-delay', null, InputOption::VALUE_REQUIRED, 'Number of seconds before progress bar is displayed in long-running task collections. Default: 2s.')
             );
+        $this->getDefinition()
+            ->addOption(
+                new InputOption('--supress-messages', null, InputOption::VALUE_NONE, 'Supress all Robo TaskIO messages.')
+            );
     }
 
     public function addInitRoboFileCommand($roboFile, $roboClass)

--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -3,8 +3,6 @@ namespace Robo\Collection;
 
 use Robo\Result;
 use Psr\Log\LogLevel;
-use Psr\Log\LoggerAwareInterface;
-use Psr\Log\LoggerAwareTrait;
 use Robo\Contract\TaskInterface;
 use Robo\Container\SimpleServiceProvider;
 use Robo\Task\StackBasedTask;

--- a/src/Common/TaskIO.php
+++ b/src/Common/TaskIO.php
@@ -4,6 +4,7 @@ namespace Robo\Common;
 use Robo\Robo;
 use Robo\TaskInfo;
 use Consolidation\Log\ConsoleLogLevel;
+use Robo\Common\ConfigAwareTrait;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
@@ -106,6 +107,9 @@ trait TaskIO
 
     protected function printTaskOutput($level, $text, $context)
     {
+        if ($this->getConfig()->isSupressed()) {
+            return;
+        }
         // Hide the progress indicator, if it is visible.
         $inProgress = $this->hideTaskProgress();
         $this->logger()->log($level, $text, $this->getTaskContext($context));

--- a/src/Config.php
+++ b/src/Config.php
@@ -3,8 +3,9 @@ namespace Robo;
 
 class Config
 {
-    const SIMULATE = 'simulate';
     const PROGRESS_BAR_AUTO_DISPLAY_INTERVAL = 'progress-delay';
+    const SIMULATE = 'simulate';
+    const SUPRESS_MESSAGES = 'supress-messages';
 
     protected $config = [];
 
@@ -16,14 +17,16 @@ class Config
     public function set($key, $value)
     {
         $this->config[$key] = $value;
+        return $this;
     }
 
     public function setGlobalOptions($input)
     {
         $globalOptions =
         [
-            self::SIMULATE => false,
             self::PROGRESS_BAR_AUTO_DISPLAY_INTERVAL => 2,
+            self::SIMULATE => false,
+            self::SUPRESS_MESSAGES => false,
         ];
 
         foreach ($globalOptions as $option => $default) {
@@ -39,5 +42,25 @@ class Config
     public function isSimulated()
     {
         return $this->get(self::SIMULATE);
+    }
+
+    public function setSimulated($simulated = true)
+    {
+        return $this->set(self::SIMULATE, $simulated);
+    }
+
+    public function isSupressed()
+    {
+        return $this->get(self::SUPRESS_MESSAGES);
+    }
+
+    public function setSupressed($supressed = true)
+    {
+        return $this->set(self::SUPRESS_MESSAGES, $supressed);
+    }
+
+    public function setProgressBarAutoDisplayInterval($interval)
+    {
+        return $this->set(self::PROGRESS_BAR_AUTO_DISPLAY_INTERVAL, $interval);
     }
 }

--- a/src/GlobalOptionsEventListener.php
+++ b/src/GlobalOptionsEventListener.php
@@ -5,7 +5,6 @@ use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Robo\Collection\CollectionBuilder;
 use Robo\Contract\ConfigAwareInterface;
 use Robo\Common\ConfigAwareTrait;
 

--- a/src/Task/BaseTask.php
+++ b/src/Task/BaseTask.php
@@ -14,9 +14,9 @@ use Robo\Common\ConfigAwareTrait;
 use Psr\Log\LoggerAwareInterface;
 
 // TODO: Ensure that ConfigAwareInterface is only used for global options; then, add it only to tasks that need it.
-abstract class BaseTask implements TaskInterface, LoggerAwareInterface, ProgressIndicatorAwareInterface, ConfigAwareInterface, InflectionInterface
+abstract class BaseTask implements TaskInterface, LoggerAwareInterface, ConfigAwareInterface, ProgressIndicatorAwareInterface, InflectionInterface
 {
-    use TaskIO; // uses LoggerAwareTrait
+    use TaskIO; // uses LoggerAwareTrait and ConfigAwareTrait
     use ProgressIndicatorAwareTrait;
     use ConfigAwareTrait;
     use InflectionTrait;

--- a/tests/unit/Task/SvnTest.php
+++ b/tests/unit/Task/SvnTest.php
@@ -26,6 +26,7 @@ class SvnTest extends \Codeception\TestCase\Test
             'executeCommand' => new \AspectMock\Proxy\Anything(),
             'getOutput' => $nullOutput,
             'logger' => $this->container->get('logger'),
+            'getConfig' => $this->container->get('config'),
             'progressIndicator' => $progressIndicator,
         ]);
     }


### PR DESCRIPTION
Related to #383, this gives users a way to turn off Robo messages -- which is to say, anything produced by TaskIO.