### PR TITLE
Ensure that 'time' is always set in the result of any collection builder

### DIFF
--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -508,6 +508,7 @@ class Collection extends BaseTask implements CollectionInterface, ContainerAware
      */
     public function complete()
     {
+        $this->detatchProgressIndicator();
         $this->runTaskListIgnoringFailures($this->completionStack);
         $this->reset();
         return $this;

--- a/src/Collection/CollectionBuilder.php
+++ b/src/Collection/CollectionBuilder.php
@@ -3,6 +3,7 @@ namespace Robo\Collection;
 
 use Robo\Config;
 use Robo\Common\IO;
+use Robo\Common\Timer;
 use Psr\Log\LogLevel;
 use League\Container\ContainerAwareInterface;
 use League\Container\ContainerAwareTrait;
@@ -22,6 +23,7 @@ class CollectionBuilder implements NestedCollectionInterface, ConfigAwareInterfa
     use ConfigAwareTrait;
     use ContainerAwareTrait;
     use LoadAllTasks;
+    use Timer;
 
     protected $collection;
     protected $currentTask;
@@ -240,6 +242,19 @@ class CollectionBuilder implements NestedCollectionInterface, ConfigAwareInterfa
      * When we run the collection builder, run everything in the collection.
      */
     public function run()
+    {
+        $this->startTimer();
+        $result = $this->runTasks();
+        $this->stopTimer();
+        $result['time'] = $this->getExecutionTime();
+        return $result;
+    }
+
+    /**
+     * If there is a single task, run it; if there is a collection, run
+     * all of its tasks.
+     */
+    protected function runTasks()
     {
         if (!$this->collection && $this->currentTask) {
             return $this->currentTask->run();

--- a/src/Common/ProgressIndicatorAwareTrait.php
+++ b/src/Common/ProgressIndicatorAwareTrait.php
@@ -84,6 +84,11 @@ trait ProgressIndicatorAwareTrait
         $this->progressIndicator->disableProgressIndicator();
     }
 
+    protected function detatchProgressIndicator()
+    {
+        $this->setProgressIndicator(null);
+    }
+
     protected function advanceProgressIndicator($steps = 1)
     {
         if (!$this->progressIndicator) {

--- a/src/Common/TimeKeeper.php
+++ b/src/Common/TimeKeeper.php
@@ -3,6 +3,10 @@ namespace Robo\Common;
 
 class TimeKeeper
 {
+    const MINUTE = 60;
+    const HOUR = 3600;
+    const DAY = 86400;
+
     protected $startedAt;
     protected $finishedAt;
 
@@ -27,5 +31,22 @@ class TimeKeeper
             return null;
         }
         return $finished - $this->startedAt;
+    }
+
+    public static function formatDuration($duration)
+    {
+        if ($duration >= self::DAY * 2) {
+            return gmdate('z \d\a\y\s H:i:s', $duration);
+        }
+        if ($duration > self::DAY) {
+            return gmdate('\1 \d\a\y H:i:s', $duration);
+        }
+        if ($duration > self::HOUR) {
+            return gmdate("H:i:s", $duration);
+        }
+        if ($duration > self::MINUTE) {
+            return gmdate("i:s", $duration);
+        }
+        return round($duration, 3).'s';
     }
 }

--- a/src/Common/Timer.php
+++ b/src/Common/Timer.php
@@ -25,7 +25,7 @@ trait Timer
     protected function getExecutionTime()
     {
         if (!isset($this->timer)) {
-            return 0;
+            return null;
         }
         return $this->timer->elapsed();
     }

--- a/src/Log/RoboLogStyle.php
+++ b/src/Log/RoboLogStyle.php
@@ -1,6 +1,7 @@
 <?php
 namespace Robo\Log;
 
+use Robo\Common\TimeKeeper;
 use Consolidation\Log\LogOutputStyler;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\OutputStyle;
@@ -46,7 +47,8 @@ class RoboLogStyle extends LogOutputStyler
         $message = parent::formatMessage($label, $message, $context, $taskNameStyle, $messageStyle);
 
         if (array_key_exists('time', $context) && !empty($context['time']) && array_key_exists('timer-label', $context)) {
-            $message .= ' ' . $context['timer-label'] . ' ' . $this->wrapFormatString($context['time'], 'fg=yellow');
+            $duration = TimeKeeper::formatDuration($context['time']);
+            $message .= ' ' . $context['timer-label'] . ' ' . $this->wrapFormatString($duration, 'fg=yellow');
         }
 
         return $message;

--- a/src/Result.php
+++ b/src/Result.php
@@ -71,15 +71,6 @@ class Result extends ResultData
         return new self($task, self::EXITCODE_OK, $message, $data);
     }
 
-    public function getExecutionTime()
-    {
-        if (!isset($this['time'])) {
-            return null;
-        }
-        $rawTime = $this['time'];
-        return round($rawTime, 3).'s';
-    }
-
     /**
      * Return a context useful for logging messages.
      */

--- a/src/ResultData.php
+++ b/src/ResultData.php
@@ -93,4 +93,17 @@ class ResultData extends \ArrayObject implements ExitCodeInterface, OutputDataIn
         $this->exchangeArray($mergedData);
         return $this;
     }
+
+    public function hasExecutionTime()
+    {
+        return isset($this['time']);
+    }
+
+    public function getExecutionTime()
+    {
+        if (!$this->hasExecutionTime()) {
+            return null;
+        }
+        return $this['time'];
+    }
 }

--- a/src/Task/Docker/Run.php
+++ b/src/Task/Docker/Run.php
@@ -152,9 +152,8 @@ class Run extends Base
     {
         $this->cidFile = sys_get_temp_dir() . '/docker_' . uniqid() . '.cid';
         $result = parent::run();
-        $time = $result->getExecutionTime();
-        $cid = $this->getCid();
-        return new Result($this, $result->getExitCode(), $result->getMessage(), ['cid' => $cid, 'time' => $time, 'name' => $this->name]);
+        $result['cid'] = $this->getCid();
+        return $result;
     }
 
     protected function getCid()

--- a/src/TaskInfo.php
+++ b/src/TaskInfo.php
@@ -18,8 +18,9 @@ class TaskInfo
     {
         $name = get_class($task);
         $name = preg_replace('~Stack^~', '', $name);
-        $name = str_replace('Robo\Task\Base\\', '', $name);
-        $name = str_replace('Robo\Task\\', '', $name);
+        $name = str_replace('Robo\\Task\Base\\', '', $name);
+        $name = str_replace('Robo\\Task\\', '', $name);
+        $name = str_replace('Robo\\Collection\\', '', $name);
         return $name;
     }
 }


### PR DESCRIPTION
Remove the 's' from the return value of Result::getExecutionTime(). Add a duration formatter.