### PR TITLE
Exclude RoboFile.php from Scrutinizer.

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,3 @@
+filter:
+    excluded_paths:
+      - "RoboFile.php"


### PR DESCRIPTION
Scrutinizer does not like our RoboFile. It is too long, too complicated, and coupled with too many components. However, this is expected, because this file is just a sample; it is expected to demonstrate a lot of different things.

Let's exclude it from analysis, since the results are not reflective of Robo as a whole.