### PR TITLE
Create a static Robo::standardServices() method

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -98,7 +98,7 @@ class RoboFile extends \Robo\Tasks
         if ($stable) $this->pharPublish();
         $this->publish();
 
-        $this->taskGitHubRelease(\Robo\Runner::VERSION)
+        $this->taskGitHubRelease(\Robo\Robo::VERSION)
             ->user($this->ask('User releasing'))
             ->password($this->askHidden('Password'))
             ->uri('consolidation-org/Robo')
@@ -118,7 +118,7 @@ class RoboFile extends \Robo\Tasks
     public function changed($addition)
     {
         return $this->taskChangelog()
-            ->version(\Robo\Runner::VERSION)
+            ->version(\Robo\Robo::VERSION)
             ->change($addition)
             ->run();
     }
@@ -132,12 +132,12 @@ class RoboFile extends \Robo\Tasks
     public function versionBump($version = '')
     {
         if (empty($version)) {
-            $versionParts = explode('.', \Robo\Runner::VERSION);
+            $versionParts = explode('.', \Robo\Robo::VERSION);
             $versionParts[count($versionParts)-1]++;
             $version = implode('.', $versionParts);
         }
-        return $this->taskReplaceInFile(__DIR__.'/src/Runner.php')
-            ->from("VERSION = '".\Robo\Runner::VERSION."'")
+        return $this->taskReplaceInFile(__DIR__.'/src/Robo.php')
+            ->from("VERSION = '".\Robo\Robo::VERSION."'")
             ->to("VERSION = '".$version."'")
             ->run();
     }

--- a/src/LoadAllTasks.php
+++ b/src/LoadAllTasks.php
@@ -5,33 +5,6 @@ trait LoadAllTasks
 {
     use TaskAccessor;
 
-    /**
-     * Return all of the service providers needed by the RoboFile.
-     * By default, we return all of the built-in Robo task providers.
-     */
-    public function getServiceProviders()
-    {
-        return
-        [
-            \Robo\Collection\loadTasks::getCollectionServices(),
-            \Robo\Task\ApiGen\loadTasks::getApiGenServices(),
-            \Robo\Task\Archive\loadTasks::getArchiveServices(),
-            \Robo\Task\Assets\loadTasks::getAssetsServices(),
-            \Robo\Task\Base\loadTasks::getBaseServices(),
-            \Robo\Task\Npm\loadTasks::getNpmServices(),
-            \Robo\Task\Bower\loadTasks::getBowerServices(),
-            \Robo\Task\Gulp\loadTasks::getGulpServices(),
-            \Robo\Task\Composer\loadTasks::getComposerServices(),
-            \Robo\Task\Development\loadTasks::getDevelopmentServices(),
-            \Robo\Task\Docker\loadTasks::getDockerServices(),
-            \Robo\Task\File\loadTasks::getFileServices(),
-            \Robo\Task\Filesystem\loadTasks::getFilesystemServices(),
-            \Robo\Task\Remote\loadTasks::getRemoteServices(),
-            \Robo\Task\Testing\loadTasks::getTestingServices(),
-            \Robo\Task\Vcs\loadTasks::getVcsServices(),
-        ];
-    }
-
     use Collection\loadTasks;
 
     // standard tasks

--- a/src/Robo.php
+++ b/src/Robo.php
@@ -9,11 +9,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\StringInput;
 
 /**
- * Manages the container reference and other static data.  Avoid using
- * this class; favor dependency injection whenever possible.
+ * Manages the container reference and other static data.  Favor
+ * using dependency injection wherever possible.  Avoid using
+ * this class directly, unless setting up a custom DI container.
  */
 class Robo
 {
+    const VERSION = '1.0.0-RC1';
+
     /**
      * The currently active container object, or NULL if not initialized yet.
      *
@@ -63,6 +66,129 @@ class Robo
     public static function hasContainer()
     {
         return static::$container !== null;
+    }
+
+    /**
+     * Create a container and initiailze it.
+     */
+    public static function createDefaultContainer($input = null, $output = null)
+    {
+        // Set up our dependency injection container.
+        $container = new Container();
+        static::configureContainer($container, $input, $output);
+        static::setContainer($container);
+
+        return $container;
+    }
+
+    /**
+     * Initialize a container with all of the default Robo services.
+     */
+    public static function configureContainer($container, $input = null, $output = null)
+    {
+        // Self-referential container refernce for the inflector
+        $container->add('container', $container);
+
+        // Create default input and output objects if they were not provided
+        if (!$input) {
+            $input = new StringInput('');
+        }
+        if (!$output) {
+            $output = new \Symfony\Component\Console\Output\ConsoleOutput();
+        }
+        $container->add('input', $input);
+        $container->add('output', $output);
+
+        // Register logging and related services.
+        $container->share('config', \Robo\Config::class);
+        $container->share('logStyler', \Robo\Log\RoboLogStyle::class);
+        $container->share('logger', \Robo\Log\RoboLogger::class)
+            ->withArgument('output')
+            ->withMethodCall('setLogOutputStyler', ['logStyler']);
+        $container->add('progressBar', \Symfony\Component\Console\Helper\ProgressBar::class)
+            ->withArgument('output');
+        $container->share('progressIndicator', \Robo\Common\ProgressIndicator::class)
+            ->withArgument('progressBar')
+            ->withArgument('output');
+        $container->share('resultPrinter', \Robo\Log\ResultPrinter::class);
+        $container->add('simulator', \Robo\Task\Simulator::class);
+        $container->share('globalOptionsEventListener', \Robo\GlobalOptionsEventListener::class);
+        $container->share('eventDispatcher', \Symfony\Component\EventDispatcher\EventDispatcher::class)
+            ->withMethodCall('addSubscriber', ['globalOptionsEventListener']);
+        $container->share('collectionProcessHook', \Robo\Collection\CollectionProcessHook::class);
+        $container->share('hookManager', \Consolidation\AnnotatedCommand\Hooks\HookManager::class)
+            ->withMethodCall('addResultProcessor', ['collectionProcessHook', '*']);
+        $container->share('formatterManager', \Consolidation\OutputFormatters\FormatterManager::class);
+        $container->share('commandProcessor', \Consolidation\AnnotatedCommand\CommandProcessor::class)
+            ->withArgument('hookManager')
+            ->withMethodCall('setFormatterManager', ['formatterManager']);
+        $container->share('commandFactory', \Consolidation\AnnotatedCommand\AnnotatedCommandFactory::class)
+            ->withMethodCall('setCommandProcessor', ['commandProcessor']);
+        $container->add('collectionBuilder', \Robo\Collection\CollectionBuilder::class);
+        $container->share('application', \Robo\Application::class)
+            ->withArgument('Robo')
+            ->withArgument(self::VERSION)
+            ->withMethodCall('setAutoExit', [false])
+            ->withMethodCall('setDispatcher', ['eventDispatcher']);
+
+        static::addInflectors($container);
+        static::addServiceProviders($container, static::standardServices());
+    }
+
+    /**
+     * Add the Robo League\Container inflectors to the container
+     */
+    public static function addInflectors($container)
+    {
+        // Register our various inflectors.
+        $container->inflector(\Robo\Contract\ConfigAwareInterface::class)
+            ->invokeMethod('setConfig', ['config']);
+        $container->inflector(\Psr\Log\LoggerAwareInterface::class)
+            ->invokeMethod('setLogger', ['logger']);
+        $container->inflector(\League\Container\ContainerAwareInterface::class)
+            ->invokeMethod('setContainer', ['container']);
+        $container->inflector(\Symfony\Component\Console\Input\InputAwareInterface::class)
+            ->invokeMethod('setInput', ['input']);
+        $container->inflector(\Robo\Contract\ProgressIndicatorAwareInterface::class)
+            ->invokeMethod('setProgressIndicator', ['progressIndicator']);
+    }
+
+    /**
+     * Register our service providers
+     */
+    public static function addServiceProviders($container, $providerList)
+    {
+        foreach ($providerList as $provider) {
+            $container->addServiceProvider($provider);
+        }
+    }
+
+    /**
+     * Return the Robo built-in task services
+     *
+     * @return SimpleServiceProvider[]
+     */
+    public static function standardServices()
+    {
+        return
+        [
+            \Robo\Collection\loadTasks::getCollectionServices(),
+            \Robo\Task\ApiGen\loadTasks::getApiGenServices(),
+            \Robo\Task\Archive\loadTasks::getArchiveServices(),
+            \Robo\Task\Assets\loadTasks::getAssetsServices(),
+            \Robo\Task\Base\loadTasks::getBaseServices(),
+            \Robo\Task\Npm\loadTasks::getNpmServices(),
+            \Robo\Task\Bower\loadTasks::getBowerServices(),
+            \Robo\Task\Gulp\loadTasks::getGulpServices(),
+            \Robo\Task\Composer\loadTasks::getComposerServices(),
+            \Robo\Task\Development\loadTasks::getDevelopmentServices(),
+            \Robo\Task\Docker\loadTasks::getDockerServices(),
+            \Robo\Task\File\loadTasks::getFileServices(),
+            \Robo\Task\Filesystem\loadTasks::getFilesystemServices(),
+            \Robo\Task\Remote\loadTasks::getRemoteServices(),
+            \Robo\Task\Testing\loadTasks::getTestingServices(),
+            \Robo\Task\Vcs\loadTasks::getVcsServices(),
+        ];
     }
 
     /**

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -11,6 +11,15 @@ class Tasks implements ContainerAwareInterface
     use LoadAllTasks;
     use IO;
 
+    /**
+     * Return all of the service providers needed by the RoboFile.
+     * By default, we return all of the built-in Robo task providers.
+     */
+    public function getServiceProviders()
+    {
+        return [];
+    }
+
     protected function stopOnFail($stopOnFail = true)
     {
         Result::$stopOnFail = $stopOnFail;

--- a/tests/_helpers/CodeHelper.php
+++ b/tests/_helpers/CodeHelper.php
@@ -22,7 +22,7 @@ class CodeHelper extends \Codeception\Module
         $progressBar = new \Symfony\Component\Console\Helper\ProgressBar(static::$testPrinter);
 
         static::$container = new \League\Container\Container();
-        \Robo\Runner::configureContainer(static::$container, null, static::$testPrinter);
+        \Robo\Robo::configureContainer(static::$container, null, static::$testPrinter);
         Robo::setContainer(static::$container);
         static::$container->add('output', static::$testPrinter);
         static::$container->add('progressBar', $progressBar);

--- a/tests/cli/_bootstrap.php
+++ b/tests/cli/_bootstrap.php
@@ -8,5 +8,5 @@ use Symfony\Component\Console\Input\StringInput;
 
 $container = new Container();
 $input = new StringInput('');
-Runner::configureContainer($container, $input);
+Robo::configureContainer($container, $input);
 Robo::setContainer($container);

--- a/tests/unit/ApplicationTest.php
+++ b/tests/unit/ApplicationTest.php
@@ -31,13 +31,13 @@ class ApplicationTest extends \Codeception\TestCase\Test
     protected function _before()
     {
         $container = new Container();
-        \Robo\Runner::configureContainer($container);
+        \Robo\Robo::configureContainer($container);
         \Robo\Robo::setContainer($container);
         $this->app = $container->get('application');
         $this->commandFactory = $container->get('commandFactory');
         $this->roboCommandFileInstance = new TestedRoboFile;
         $this->roboCommandFileInstance->setContainer(\Robo\Robo::getContainer());
-        \Robo\Runner::addServiceProviders($container, $this->roboCommandFileInstance->getServiceProviders());
+        \Robo\Robo::addServiceProviders($container, $this->roboCommandFileInstance->getServiceProviders());
         $commandList = $this->commandFactory->createCommandsFromClass($this->roboCommandFileInstance);
         foreach ($commandList as $command) {
             $this->app->add($command);


### PR DESCRIPTION
Provide Robo's standard service list. This makes it easier for external programs that use Robo as a library to configure their DI container. It was a mistake to move this list to a non-static method in RC1.