### PR TITLE
Add return type to @method tag to enable autocomplete

### DIFF
--- a/src/Task/Filesystem/FilesystemStack.php
+++ b/src/Task/Filesystem/FilesystemStack.php
@@ -27,16 +27,16 @@ use Symfony\Component\Filesystem\Exception\IOException;
  * ?>
  * ```
  *
- * @method mkdir($dir)
- * @method touch($file)
- * @method copy($from, $to, $force = null)
- * @method chmod($file, $permissions, $umask = null, $recursive = null)
- * @method chgrp($file, $group, $recursive = null)
- * @method chown($file, $user, $recursive = null)
- * @method remove($file)
- * @method rename($from, $to)
- * @method symlink($from, $to)
- * @method mirror($from, $to)
+ * @method $this mkdir($dir)
+ * @method $this touch($file)
+ * @method $this copy($from, $to, $force = null)
+ * @method $this chmod($file, $permissions, $umask = null, $recursive = null)
+ * @method $this chgrp($file, $group, $recursive = null)
+ * @method $this chown($file, $user, $recursive = null)
+ * @method $this remove($file)
+ * @method $this rename($from, $to)
+ * @method $this symlink($from, $to)
+ * @method $this mirror($from, $to)
  */
 class FilesystemStack extends StackBasedTask
 {


### PR DESCRIPTION
Add return type to FilesystemStack @method tag to enable auto complete when chaining methods in IDEs, eg `$this->taskFilesystemStack()->copy($source, $destination)->run();`.