### PR TITLE
Rename 'Robo standalone scripts' to 'Robo scripts'.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 * [Extract] task added
 * [Pack] task added
 * [TmpDir], [WorkDir] and [TmpFile] tasks added
-* Support standalone Robo scripts that allows scripts starting with `#!/usr/bin/env robo` to define multiple robo commands.  Use `#!/usr/bin/env robo run` to define a single robo command implemented by the `run()` method.
+* Support Robo scripts that allows scripts starting with `#!/usr/bin/env robo` to define multiple robo commands.  Use `#!/usr/bin/env robo run` to define a single robo command implemented by the `run()` method.
 * Provide ProgresIndicatorAwareInterface and ProgressIndicatorAwareTrait that make it easy to add progress indicators to tasks
 * Add --simulate mode that causes tasks to print what they would have done, but make no changes
 * Add `robo generate:task` code-generator to make new stack-based task wrappers around existing classes

--- a/script.robo
+++ b/script.robo
@@ -2,34 +2,58 @@
 <?php
 
 /**
- * Standalone Robo script.
+ * Robo script.
  *
- * This file may be executed from the shell as if it were a
- * bash script.
+ * This file may be executed from the shell as if it were a bash script.
  *
  * Example:
  *
- * $ ./script.robo foo bar
- * ➜  This is a standalone Robo script, bar
+ *   $ ./script.robo foo bar
+ *   ➜  This is a Robo script, bar
  *
- * Note that in order for this to work, the 'robo' script
+ * If the script has only one command, then you may remove the need to
+ * specify it on the commandline by naming it on the `#!` line.
+ *
+ * e.g. if the first line is `#!/usr/bin/env robo foo`:
+ *
+ *   $ ./script.robo bar
+ *   ➜  This is a Robo script, bar
+ *
+ * Note that in order for Robo scripts to work, the 'robo' application
  * must be in your $PATH.  Usually, this is done by installing
- * Robo via 'composer global require', and placing ~/.composer/vendor/bin
- * on your $PATH.  Then, any Robo libraries that are also installed
- * via 'composer global require' will be available for use in all
- * Robo standalone scripts.
+ * Robo via `composer global require`, and placing ~/.composer/vendor/bin
+ * on your $PATH.  Robo libraries that are also installed via `composer global
+ * require` will be available for use in your Robo scripts, provided that
+ * they are loaded via the `getServiceProviders` method of the script.
+ *
+ * See also: https://github.com/consolidation-org/cgr
  */
 class MyRoboScript extends \Robo\Tasks
 {
     /**
      * Foo
      *
-     * A demonstration of a command in a standalone Robo script.
+     * A demonstration of a command in a Robo script.
      *
      * @param string $name a name that is printed.
      */
     public function foo($name)
     {
-        $this->say("This is a standalone Robo script, $name");
+        $this->say("This is a Robo script, $name");
+    }
+
+    /**
+     * Load any external Robo tasks
+     *
+     * e.g. after `composer global require externalproject/extra`:
+     *
+     *      return
+     *      [
+     *          \ExternalProject\Task\Extra\loadTasks::getExtraServices(),
+     *      ];
+     */
+    public function getServiceProviders()
+    {
+        return [];
     }
 }


### PR DESCRIPTION
It was a misnomer to call 'Robo scripts' "standalone", because these scripts require the Robo application in your $PATH, and this is not part of the script.

We should reserve the term "standalone" for applications derived from Robo that contain the entire Robo application, e.g. by requiring Robo in composer.json.