### PR TITLE
Do not automatically chdir to the directory containing the RoboFile.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Add `robo generate:task` code-generator to make new stack-based task wrappers around existing classes
 * Add `robo sniff` by @dustinleblanc. Runs the PHP code sniffer followed by the code beautifier, if needed.
 * Implement ArrayInterface for Result class, so result data may be accessed like an array 
+* Using `--load-from` no longer changes the current working directory to the path where the RoboFile is located.
 * Defer execution of operations in taskWriteToFile until the run() method
 * Add Write::textIfMatch() for taskWriteToFile
 * ResourceExistenceChecker used for error checking in DeleteDir, CopyDir, CleanDir and Concat tasks by @burzum

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -60,8 +60,6 @@ class Runner
         }
 
         $this->dir = realpath($this->dir);
-        chdir($this->dir);
-
         if (!file_exists($this->dir . DIRECTORY_SEPARATOR . $this->roboFile)) {
             return false;
         }


### PR DESCRIPTION
Does the `chdir` in the `loadRoboFile()` function serve any important purpose?  This has no effect unless --load-from is used (since otherwise, `$dir == getcwd()` already); however, in the --load-from scenario, this chdir can be quite destructive.  I did a couple of experiments with different ways to package and use Robo to conveniently create simple scripts, and this chdir often gets in the way.  I think that the best thing to do would be to just remove it -- or, if really necessary for some folks, we could add a --with-chdir option or somesuch to optionally include it if desired.

I think it's worth the b/c break to fix this, because otherwise it's hard to package up a Robo-based script that operates on files relative to the cwd (as just about all existing shell commands do).