### PR TITLE
IO interface

### DIFF
--- a/src/Collection/CollectionBuilder.php
+++ b/src/Collection/CollectionBuilder.php
@@ -2,7 +2,6 @@
 namespace Robo\Collection;
 
 use Robo\Config;
-use Robo\Common\IO;
 use Robo\Common\Timer;
 use Psr\Log\LogLevel;
 use Robo\Contract\TaskInterface;

--- a/src/Common/IO.php
+++ b/src/Common/IO.php
@@ -12,31 +12,12 @@ use Symfony\Component\Console\Question\Question;
 
 trait IO
 {
-    /**
-     * @return OutputInterface
-     */
-    protected function getOutput()
-    {
-        if (!Robo::hasService('output')) {
-            return new NullOutput();
-        }
-        return Robo::output();
-    }
-
-    /**
-     * @return InputInterface
-     */
-    protected function getInput()
-    {
-        if (!Robo::hasService('input')) {
-            return new ArgvInput();
-        }
-        return Robo::input();
-    }
+    use InputAwareTrait;
+    use OutputAwareTrait;
 
     protected function decorationCharacter($nonDecorated, $decorated)
     {
-        if (!$this->getOutput()->isDecorated() || (strncasecmp(PHP_OS, 'WIN', 3) == 0)) {
+        if (!$this->output()->isDecorated() || (strncasecmp(PHP_OS, 'WIN', 3) == 0)) {
             return $nonDecorated;
         }
         return $decorated;
@@ -97,7 +78,7 @@ trait IO
 
     private function doAsk(Question $question)
     {
-        return $this->getDialog()->ask($this->getInput(), $this->getOutput(), $question);
+        return $this->getDialog()->ask($this->input(), $this->output(), $question);
     }
 
     private function formatQuestion($message)
@@ -112,6 +93,6 @@ trait IO
 
     private function writeln($text)
     {
-        $this->getOutput()->writeln($text);
+        $this->output()->writeln($text);
     }
 }

--- a/src/Common/InputAwareTrait.php
+++ b/src/Common/InputAwareTrait.php
@@ -2,6 +2,7 @@
 
 namespace Robo\Common;
 
+use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputInterface;
 
 trait InputAwareTrait
@@ -26,6 +27,15 @@ trait InputAwareTrait
      */
     protected function input()
     {
+        if (!isset($this->input)) {
+            $this->setInput(new ArgvInput());
+        }
         return $this->input;
+    }
+
+    // Backwards compatibility.
+    protected function getInput()
+    {
+        return $this->input();
     }
 }

--- a/src/Common/InputAwareTrait.php
+++ b/src/Common/InputAwareTrait.php
@@ -24,7 +24,7 @@ trait InputAwareTrait
     /**
      * @inheritdoc
      */
-    public function input()
+    protected function input()
     {
         return $this->input;
     }

--- a/src/Common/OutputAwareTrait.php
+++ b/src/Common/OutputAwareTrait.php
@@ -24,7 +24,7 @@ trait OutputAwareTrait
     /**
      * @inheritdoc
      */
-    public function output()
+    protected function output()
     {
         return $this->output;
     }

--- a/src/Common/OutputAwareTrait.php
+++ b/src/Common/OutputAwareTrait.php
@@ -2,6 +2,7 @@
 
 namespace Robo\Common;
 
+use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 trait OutputAwareTrait
@@ -26,6 +27,15 @@ trait OutputAwareTrait
      */
     protected function output()
     {
+        if (!isset($this->output)) {
+            $this->setOutput(new NullOutput());
+        }
         return $this->output;
+    }
+
+    // Backwards compatibility
+    protected function getOutput()
+    {
+        return $this->output();
     }
 }

--- a/src/Common/ResourceExistenceChecker.php
+++ b/src/Common/ResourceExistenceChecker.php
@@ -3,7 +3,7 @@ namespace Robo\Common;
 
 trait ResourceExistenceChecker
 {
-    use IO;
+    use TaskIO;
 
     /**
      * Checks if the given input is a file or folder.

--- a/src/Config.php
+++ b/src/Config.php
@@ -6,6 +6,7 @@ class Config
     const PROGRESS_BAR_AUTO_DISPLAY_INTERVAL = 'progress-delay';
     const SIMULATE = 'simulate';
     const SUPRESS_MESSAGES = 'supress-messages';
+    const DECORATED = 'decorated';
 
     protected $config = [];
 
@@ -47,6 +48,16 @@ class Config
     public function setSimulated($simulated = true)
     {
         return $this->set(self::SIMULATE, $simulated);
+    }
+
+    public function isDecorated()
+    {
+        return $this->get(self::DECORATED);
+    }
+
+    public function setDecorated($decorated = true)
+    {
+        return $this->set(self::DECORATED, $decorated);
     }
 
     public function isSupressed()

--- a/src/Contract/IOAwareInterface.php
+++ b/src/Contract/IOAwareInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * Marker interface for tasks that use the IO trait
+ */
+
+namespace Robo\Contract;
+
+use \Symfony\Component\Console\Input\InputAwareInterface;
+
+interface IOAwareInterface extends OutputAwareInterface, InputAwareInterface
+{
+}

--- a/src/Robo.php
+++ b/src/Robo.php
@@ -100,7 +100,8 @@ class Robo
         $container->add('output', $output);
 
         // Register logging and related services.
-        $container->share('config', \Robo\Config::class);
+        $container->share('config', \Robo\Config::class)
+            ->withMethodCall('setDecorated', [$output->isDecorated()]);
         $container->share('logStyler', \Robo\Log\RoboLogStyle::class);
         $container->share('logger', \Robo\Log\RoboLogger::class)
             ->withArgument('output')

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -1,7 +1,6 @@
 <?php
 namespace Robo;
 
-use Robo\Common\IO;
 use League\Container\Container;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\ArgvInput;
@@ -11,8 +10,6 @@ use Robo\Contract\BuilderAwareInterface;
 
 class Runner
 {
-    use IO;
-
     const ROBOCLASS = 'RoboFile';
     const ROBOFILE = 'RoboFile.php';
 

--- a/src/Task/Base/SymfonyCommand.php
+++ b/src/Task/Base/SymfonyCommand.php
@@ -1,6 +1,7 @@
 <?php
 namespace Robo\Task\Base;
 
+use Robo\Robo;
 use Robo\Result;
 use Robo\Task\BaseTask;
 use Symfony\Component\Console\Command\Command;
@@ -27,8 +28,6 @@ use Symfony\Component\Console\Input\InputInterface;
  */
 class SymfonyCommand extends BaseTask
 {
-    use \Robo\Common\IO;
-
     /**
      * @var SymfonyCommand
      */
@@ -62,7 +61,7 @@ class SymfonyCommand extends BaseTask
         $this->printTaskInfo('Running command {command}', ['command' => $this->command->getName()]);
         return new Result(
             $this,
-            $this->command->run(new ArrayInput($this->input), $this->getOutput())
+            $this->command->run(new ArrayInput($this->input), Robo::output())
         );
     }
 }

--- a/src/Task/Composer/Base.php
+++ b/src/Task/Composer/Base.php
@@ -97,17 +97,13 @@ abstract class Base extends BaseTask
         if (!$this->command) {
             throw new TaskException(__CLASS__, "Neither local composer.phar nor global composer installation could be found.");
         }
-
-        // TODO: We are using the active Output object to determine if we should
-        // automatically use 'ansi' mode. Instead, we should make this task a
-        // ConfigAwareInterface, and add a configuration setting for this.
-        if (Robo::output()->isDecorated()) {
-            $this->ansi();
-        }
     }
 
     public function getCommand()
     {
+        if (!isset($this->ansi) && $this->getConfig()->isDecorated()) {
+            $this->ansi();
+        }
         $this->option($this->prefer)
             ->option($this->dev)
             ->option($this->optimizeAutoloader)

--- a/src/Task/Composer/Base.php
+++ b/src/Task/Composer/Base.php
@@ -1,13 +1,13 @@
 <?php
 namespace Robo\Task\Composer;
 
+use Robo\Robo;
 use Robo\Task\BaseTask;
 use Robo\Exception\TaskException;
 
 abstract class Base extends BaseTask
 {
     use \Robo\Common\ExecOneCommand;
-    use \Robo\Common\IO;
 
     protected $prefer;
     protected $dev;
@@ -98,7 +98,10 @@ abstract class Base extends BaseTask
             throw new TaskException(__CLASS__, "Neither local composer.phar nor global composer installation could be found.");
         }
 
-        if ($this->getOutput()->isDecorated()) {
+        // TODO: We are using the active Output object to determine if we should
+        // automatically use 'ansi' mode. Instead, we should make this task a
+        // ConfigAwareInterface, and add a configuration setting for this.
+        if (Robo::output()->isDecorated()) {
             $this->ansi();
         }
     }

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -3,9 +3,10 @@ namespace Robo;
 
 use Robo\Common\IO;
 use Robo\Contract\BuilderAwareInterface;
+use Robo\Contract\IOAwareInterface;
 use Robo\Common\BuilderAwareTrait;
 
-class Tasks implements BuilderAwareInterface
+class Tasks implements BuilderAwareInterface, IOAwareInterface
 {
     use BuilderAwareTrait;
     use LoadAllTasks;

--- a/tests/unit/Common/ResourceExistenceChecker.php
+++ b/tests/unit/Common/ResourceExistenceChecker.php
@@ -15,7 +15,7 @@ class ResourceExistenceCheckerTest extends \Codeception\TestCase\Test
     {
         $this->apigen = test::double('Robo\Task\ApiGen\ApiGen', [
             'executeCommand' => null,
-            'getOutput' => new \Symfony\Component\Console\Output\NullOutput()
+            'output' => new \Symfony\Component\Console\Output\NullOutput()
         ]);
         if (!defined('DS')) {
             define('DS', DIRECTORY_SEPARATOR);

--- a/tests/unit/OutputTest.php
+++ b/tests/unit/OutputTest.php
@@ -1,5 +1,6 @@
 <?php
 use AspectMock\Test as test;
+use Robo\Robo;
 use Robo\Common\IO;
 
 class OutputTest extends \Codeception\TestCase\Test
@@ -8,11 +9,10 @@ class OutputTest extends \Codeception\TestCase\Test
         say as public;
         yell as public;
         ask as public;
-        getOutput as protected;
+        output as protected;
     }
 
     protected $expectedAnswer;
-
 
     /**
      * @var \CodeGuy
@@ -27,6 +27,7 @@ class OutputTest extends \Codeception\TestCase\Test
     protected function _before()
     {
         $this->dialog = new Symfony\Component\Console\Helper\QuestionHelper;
+       $this->setOutput(Robo::service('output'));
     }
 
     public function testSay()

--- a/tests/unit/OutputTest.php
+++ b/tests/unit/OutputTest.php
@@ -27,7 +27,7 @@ class OutputTest extends \Codeception\TestCase\Test
     protected function _before()
     {
         $this->dialog = new Symfony\Component\Console\Helper\QuestionHelper;
-       $this->setOutput(Robo::service('output'));
+        $this->setOutput(Robo::service('output'));
     }
 
     public function testSay()

--- a/tests/unit/Task/ApiGenTest.php
+++ b/tests/unit/Task/ApiGenTest.php
@@ -15,7 +15,7 @@ class ApiGenTest extends \Codeception\TestCase\Test
     {
         $this->apigen = test::double('Robo\Task\ApiGen\ApiGen', [
             'executeCommand' => null,
-            'getOutput' => new \Symfony\Component\Console\Output\NullOutput()
+            'output' => new \Symfony\Component\Console\Output\NullOutput()
         ]);
 
         $this->container = Robo::getContainer();

--- a/tests/unit/Task/AtoumTest.php
+++ b/tests/unit/Task/AtoumTest.php
@@ -13,7 +13,7 @@ class AtoumTest extends \Codeception\TestCase\Test
     {
         $this->atoum = test::double('Robo\Task\Testing\Atoum', [
             'executeCommand' => null,
-            'getOutput' => new \Symfony\Component\Console\Output\NullOutput()
+            'output' => new \Symfony\Component\Console\Output\NullOutput()
         ]);
     }
 

--- a/tests/unit/Task/BowerTest.php
+++ b/tests/unit/Task/BowerTest.php
@@ -14,7 +14,7 @@ class BowerTest extends \Codeception\TestCase\Test
     protected function _before()
     {
         $this->baseBower = test::double('Robo\Task\Bower\Base', [
-            'getOutput' => new \Symfony\Component\Console\Output\NullOutput()
+            'output' => new \Symfony\Component\Console\Output\NullOutput()
         ]);
     }
     // tests

--- a/tests/unit/Task/CodeceptionTest.php
+++ b/tests/unit/Task/CodeceptionTest.php
@@ -15,7 +15,7 @@ class CodeceptionTest extends \Codeception\TestCase\Test
     {
         $this->codecept = test::double('Robo\Task\Testing\Codecept', [
             'executeCommand' => null,
-            'getOutput' => new \Symfony\Component\Console\Output\NullOutput()
+            'output' => new \Symfony\Component\Console\Output\NullOutput()
         ]);
     }
 

--- a/tests/unit/Task/ComposerTest.php
+++ b/tests/unit/Task/ComposerTest.php
@@ -14,13 +14,13 @@ class ComposerTest extends \Codeception\TestCase\Test
     protected function _before()
     {
         $this->baseComposer = test::double('Robo\Task\Composer\Base', [
-            'getOutput' => new \Symfony\Component\Console\Output\NullOutput()
+            'output' => new \Symfony\Component\Console\Output\NullOutput(),
         ]);
     }
     // tests
     public function testComposerInstall()
     {
-        $composer = test::double('Robo\Task\Composer\Install', ['executeCommand' => null]);
+        $composer = test::double('Robo\Task\Composer\Install', ['executeCommand' => null, 'getConfig' => new \Robo\Config()]);
 
         (new \Robo\Task\Composer\Install('composer'))->run();
         $composer->verifyInvoked('executeCommand', ['composer install']);
@@ -36,9 +36,29 @@ class ComposerTest extends \Codeception\TestCase\Test
         $composer->verifyInvoked('executeCommand', ['composer install --optimize-autoloader']);
     }
 
+    public function testComposerInstallAnsi()
+    {
+        $config = new \Robo\Config();
+        $config->setDecorated(true);
+        $composer = test::double('Robo\Task\Composer\Install', ['executeCommand' => null, 'getConfig' => $config]);
+
+        (new \Robo\Task\Composer\Install('composer'))->run();
+        $composer->verifyInvoked('executeCommand', ['composer install --ansi']);
+
+        (new \Robo\Task\Composer\Install('composer'))
+            ->preferSource()
+            ->run();
+        $composer->verifyInvoked('executeCommand', ['composer install --prefer-source --ansi']);
+
+        (new \Robo\Task\Composer\Install('composer'))
+            ->optimizeAutoloader()
+            ->run();
+        $composer->verifyInvoked('executeCommand', ['composer install --optimize-autoloader --ansi']);
+    }
+
     public function testComposerUpdate()
     {
-        $composer = test::double('Robo\Task\Composer\Update', ['executeCommand' => null]);
+        $composer = test::double('Robo\Task\Composer\Update', ['executeCommand' => null, 'getConfig' => new \Robo\Config()]);
 
         (new \Robo\Task\Composer\Update('composer'))->run();
         $composer->verifyInvoked('executeCommand', ['composer update']);
@@ -51,7 +71,7 @@ class ComposerTest extends \Codeception\TestCase\Test
 
     public function testComposerDumpAutoload()
     {
-        $composer = test::double('Robo\Task\Composer\DumpAutoload', ['executeCommand' => null]);
+        $composer = test::double('Robo\Task\Composer\DumpAutoload', ['executeCommand' => null, 'getConfig' => new \Robo\Config()]);
 
         (new \Robo\Task\Composer\DumpAutoload('composer'))->run();
         $composer->verifyInvoked('executeCommand', ['composer dump-autoload']);
@@ -75,7 +95,7 @@ class ComposerTest extends \Codeception\TestCase\Test
 
     public function testComposerValidate()
     {
-        $composer = test::double('Robo\Task\Composer\Validate', ['executeCommand' => null]);
+        $composer = test::double('Robo\Task\Composer\Validate', ['executeCommand' => null, 'getConfig' => new \Robo\Config()]);
 
         (new \Robo\Task\Composer\Validate('composer'))->run();
         $composer->verifyInvoked('executeCommand', ['composer validate']);
@@ -109,11 +129,12 @@ class ComposerTest extends \Codeception\TestCase\Test
     public function testComposerInstallCommand()
     {
         verify(
-            (new \Robo\Task\Composer\Install('composer'))->getCommand()
+            (new \Robo\Task\Composer\Install('composer'))->setConfig(new \Robo\Config())->getCommand()
         )->equals('composer install');
 
         verify(
             (new \Robo\Task\Composer\Install('composer'))
+                ->setConfig(new \Robo\Config())
                 ->noDev()
                 ->preferDist()
                 ->optimizeAutoloader()
@@ -124,11 +145,12 @@ class ComposerTest extends \Codeception\TestCase\Test
     public function testComposerUpdateCommand()
     {
         verify(
-            (new \Robo\Task\Composer\Update('composer'))->getCommand()
+            (new \Robo\Task\Composer\Update('composer'))->setConfig(new \Robo\Config())->getCommand()
         )->equals('composer update');
 
         verify(
             (new \Robo\Task\Composer\Update('composer'))
+                ->setConfig(new \Robo\Config())
                 ->noDev()
                 ->preferDist()
                 ->getCommand()
@@ -136,6 +158,7 @@ class ComposerTest extends \Codeception\TestCase\Test
 
         verify(
             (new \Robo\Task\Composer\Update('composer'))
+                ->setConfig(new \Robo\Config())
                 ->noDev()
                 ->preferDist()
                 ->optimizeAutoloader()
@@ -146,23 +169,26 @@ class ComposerTest extends \Codeception\TestCase\Test
     public function testComposerDumpAutoloadCommand()
     {
         verify(
-            (new \Robo\Task\Composer\DumpAutoload('composer'))->getCommand()
+            (new \Robo\Task\Composer\DumpAutoload('composer'))->setConfig(new \Robo\Config())->getCommand()
         )->equals('composer dump-autoload');
 
         verify(
             (new \Robo\Task\Composer\DumpAutoload('composer'))
+                ->setConfig(new \Robo\Config())
                 ->noDev()
                 ->getCommand()
         )->equals('composer dump-autoload --no-dev');
 
         verify(
             (new \Robo\Task\Composer\DumpAutoload('composer'))
+                ->setConfig(new \Robo\Config())
                 ->optimize()
                 ->getCommand()
         )->equals('composer dump-autoload --optimize');
 
         verify(
             (new \Robo\Task\Composer\DumpAutoload('composer'))
+                ->setConfig(new \Robo\Config())
                 ->optimize()
                 ->noDev()
                 ->getCommand()
@@ -172,41 +198,47 @@ class ComposerTest extends \Codeception\TestCase\Test
     public function testComposerValidateCommand()
     {
         verify(
-            (new \Robo\Task\Composer\Validate('composer'))->getCommand()
+            (new \Robo\Task\Composer\Validate('composer'))->setConfig(new \Robo\Config())->getCommand()
         )->equals('composer validate');
 
         verify(
             (new \Robo\Task\Composer\Validate('composer'))
+                ->setConfig(new \Robo\Config())
                 ->noCheckAll()
                 ->getCommand()
         )->equals('composer validate --no-check-all');
 
         verify(
             (new \Robo\Task\Composer\Validate('composer'))
+                ->setConfig(new \Robo\Config())
                 ->noCheckLock()
                 ->getCommand()
         )->equals('composer validate --no-check-lock');
 
         verify(
             (new \Robo\Task\Composer\Validate('composer'))
+                ->setConfig(new \Robo\Config())
                 ->noCheckPublish()
                 ->getCommand()
         )->equals('composer validate --no-check-publish');
 
         verify(
             (new \Robo\Task\Composer\Validate('composer'))
+                ->setConfig(new \Robo\Config())
                 ->withDependencies()
                 ->getCommand()
         )->equals('composer validate --with-dependencies');
 
         verify(
             (new \Robo\Task\Composer\Validate('composer'))
+                ->setConfig(new \Robo\Config())
                 ->strict()
                 ->getCommand()
         )->equals('composer validate --strict');
 
         verify(
             (new \Robo\Task\Composer\Validate('composer'))
+                ->setConfig(new \Robo\Config())
                 ->noCheckAll()
                 ->noCheckLock()
                 ->noCheckPublish()
@@ -215,5 +247,4 @@ class ComposerTest extends \Codeception\TestCase\Test
                 ->getCommand()
         )->equals('composer validate --no-check-all --no-check-lock --no-check-publish --with-dependencies --strict');
     }
-
 }

--- a/tests/unit/Task/ExecTaskTest.php
+++ b/tests/unit/Task/ExecTaskTest.php
@@ -17,7 +17,7 @@ class ExecTaskTest extends \Codeception\TestCase\Test
             'getOutput' => 'Hello world',
             'getExitCode' => 0
         ]);
-        test::double('Robo\Task\Base\Exec', ['getOutput' => new \Symfony\Component\Console\Output\NullOutput()]);
+        test::double('Robo\Task\Base\Exec', ['output' => new \Symfony\Component\Console\Output\NullOutput()]);
     }
 
     public function testExec()

--- a/tests/unit/Task/GitTest.php
+++ b/tests/unit/Task/GitTest.php
@@ -14,7 +14,7 @@ class GitTest extends \Codeception\TestCase\Test
     {
         $this->git = test::double('Robo\Task\Vcs\GitStack', [
             'executeCommand' => new \AspectMock\Proxy\Anything(),
-            'getOutput' => new \Symfony\Component\Console\Output\NullOutput()
+            'output' => new \Symfony\Component\Console\Output\NullOutput()
         ]);
     }
 

--- a/tests/unit/Task/GulpTest.php
+++ b/tests/unit/Task/GulpTest.php
@@ -12,7 +12,7 @@ class GulpTest extends \Codeception\TestCase\Test
     protected function _before()
     {
         $this->baseGulp = test::double('Robo\Task\Gulp\Base', [
-            'getOutput' => new \Symfony\Component\Console\Output\NullOutput()
+            'output' => new \Symfony\Component\Console\Output\NullOutput()
         ]);
     }
 

--- a/tests/unit/Task/HgTest.php
+++ b/tests/unit/Task/HgTest.php
@@ -19,7 +19,7 @@ class HgTest extends \Codeception\TestCase\Test
     {
         $this->hg = Test::double('Robo\Task\Vcs\HgStack', [
             'executeCommand' => new \AspectMock\Proxy\Anything(),
-            'getOutput' => new \Symfony\Component\Console\Output\NullOutput()
+            'output' => new \Symfony\Component\Console\Output\NullOutput()
         ]);
         $this->hgStack = (new \Robo\Task\Vcs\HgStack('hg'));
     }

--- a/tests/unit/Task/NpmTest.php
+++ b/tests/unit/Task/NpmTest.php
@@ -12,7 +12,7 @@ class NpmTest extends \Codeception\TestCase\Test
     protected function _before()
     {
         $this->baseNpm = test::double('Robo\Task\Npm\Base', [
-            'getOutput' => new \Symfony\Component\Console\Output\NullOutput()
+            'output' => new \Symfony\Component\Console\Output\NullOutput()
         ]);
     }
 

--- a/tests/unit/Task/PHPServerTest.php
+++ b/tests/unit/Task/PHPServerTest.php
@@ -18,7 +18,7 @@ class PHPServerTest extends \Codeception\TestCase\Test
             'getOutput' => 'Hello world',
             'getExitCode' => 0
         ]);
-        test::double('Robo\Task\Development\PhpServer', ['getOutput' => new \Symfony\Component\Console\Output\NullOutput()]);
+        test::double('Robo\Task\Development\PhpServer', ['output' => new \Symfony\Component\Console\Output\NullOutput()]);
     }
 
     public function testServerBackgroundRun()

--- a/tests/unit/Task/PHPUnitTest.php
+++ b/tests/unit/Task/PHPUnitTest.php
@@ -13,7 +13,7 @@ class PHPUnitTest extends \Codeception\TestCase\Test
     {
         $this->phpunit = test::double('Robo\Task\Testing\PHPUnit', [
             'executeCommand' => null,
-            'getOutput' => new \Symfony\Component\Console\Output\NullOutput()
+            'output' => new \Symfony\Component\Console\Output\NullOutput()
         ]);
     }
 

--- a/tests/unit/Task/PhpspecTest.php
+++ b/tests/unit/Task/PhpspecTest.php
@@ -13,7 +13,7 @@ class PhpspecTest extends \Codeception\TestCase\Test
     {
         $this->phpspec = test::double('Robo\Task\Testing\Phpspec', [
             'executeCommand' => null,
-            'getOutput' => new \Symfony\Component\Console\Output\NullOutput()
+            'output' => new \Symfony\Component\Console\Output\NullOutput()
         ]);
     }
 

--- a/tests/unit/Task/SvnTest.php
+++ b/tests/unit/Task/SvnTest.php
@@ -19,7 +19,7 @@ class SvnTest extends \Codeception\TestCase\Test
 
         $this->svn = test::double('Robo\Task\Vcs\SvnStack', [
             'executeCommand' => new \AspectMock\Proxy\Anything(),
-            'getOutput' => $nullOutput,
+            'output' => $nullOutput,
             'logger' => Robo::logger(),
             'getConfig' => Robo::config(),
             'progressIndicator' => $progressIndicator,


### PR DESCRIPTION
Rename getOutput() and getInput() to output() and input(); remove globals from the IO trait, and build IO off of InputAwareTrait and OutputAwareTrait.

`getInput()` and `getOutput()` methods maintained for backwards compatibility.

