### PR TITLE
Atoum documentation fixes

### DIFF
--- a/docs/tasks/Testing.md
+++ b/docs/tasks/Testing.md
@@ -20,7 +20,7 @@ $this->taskAtoum()
 * `bootstrap($file)`  Path to the bootstrap file.
 * `configFile($file)`  Path to the config file.
 * `debug()`  Use atoum's debug mode.
-* `files($files)`  Test file ou test files to run.
+* `files($files)`  Test file or test files to run.
 * `directories($directories)`  Test directory or directories to run.
 * `dir($dir)`  changes working directory of command
 * `printed($arg)`  Should command output be printed

--- a/docs/tasks/Testing.md
+++ b/docs/tasks/Testing.md
@@ -7,7 +7,7 @@ Runs [atoum](http://atoum.org/) tests
 ``` php
 <?php
 $this->taskAtoum()
- ->file('path/to/test.php')
+ ->files('path/to/test.php')
  ->configFile('config/dev.php')
  ->run()
 

--- a/src/Task/Testing/Atoum.php
+++ b/src/Task/Testing/Atoum.php
@@ -112,7 +112,7 @@ class Atoum extends BaseTask implements CommandInterface, PrintedInterface
     }
 
     /**
-     * Test file ou test files to run.
+     * Test file or test files to run.
      *
      * @param string|array
      *

--- a/src/Task/Testing/Atoum.php
+++ b/src/Task/Testing/Atoum.php
@@ -11,7 +11,7 @@ use Robo\Task\BaseTask;
  * ``` php
  * <?php
  * $this->taskAtoum()
- *  ->file('path/to/test.php')
+ *  ->files('path/to/test.php')
  *  ->configFile('config/dev.php')
  *  ->run()
  *


### PR DESCRIPTION
Fixes a misleading reference to non-existent `file()` method in Atoum doc as well as a minor typo. Refer to individual commit messages for full details.