### PR TITLE
Fix: disallow passing multiple test files to PHPUnit via files()

### DIFF
--- a/docs/tasks/Testing.md
+++ b/docs/tasks/Testing.md
@@ -95,7 +95,7 @@ $this->taskPHPUnit()
 * `bootstrap($file)` 
 * `configFile($file)` 
 * `debug()` 
-* `files($files)`  Test files to run.
+* `files($files)`  Directory of test files or single test file to run.
 * `dir($dir)`  changes working directory of command
 * `printed($arg)`  Should command output be printed
 * `arg($arg)`  Pass argument to executable

--- a/src/Task/Testing/PHPUnit.php
+++ b/src/Task/Testing/PHPUnit.php
@@ -25,7 +25,8 @@ class PHPUnit extends BaseTask implements CommandInterface, PrintedInterface
     protected $command;
 
     /**
-     * Test files to run, they're appended to the command and arguments.
+     * Directory of test files or single test file to run. Appended to
+     * the command and arguments.
      *
      * @var string
      */
@@ -109,17 +110,15 @@ class PHPUnit extends BaseTask implements CommandInterface, PrintedInterface
     }
 
     /**
-     * Test files to run.
+     * Directory of test files or single test file to run.
      *
-     * @param string|array A single file or a list of files.
+     * @param string A single test file or a directory containing test files.
      * @return $this
      */
     public function files($files)
     {
-        if (is_string($files)) {
-            $files = [$files];
-        }
-        $this->files = ' ' . implode(',', $files);
+        $this->files = ' ' . $files;
+
         return $this;
     }
 


### PR DESCRIPTION
Unfortunately, PHPUnit does not support passing a list of test files
to run via the command-line interface. However, the current
implementation of the PHPUnit task allowed passing an array of files
to its `files()` method, which it would then append to the command as
a string of comma-delimited files, which would cause the PHPUnit
executable to fail.

The PHPUnit executable supports either a path to a directory
containing multiple test files or a path to a single test file as a
command-line argument.

This fixes the issue by allowing only a single string to be passed via
`files()`.

Signed-off-by: Antoine Busque <antoine.busque@pillrcompany.com>