### PR TITLE
Fixes loading the _exec() shortcut. 'Class taskExec does not exist'.

### DIFF
--- a/src/Task/Base/loadShortcuts.php
+++ b/src/Task/Base/loadShortcuts.php
@@ -11,6 +11,6 @@ trait loadShortcuts
      */
     protected function _exec($command)
     {
-        return $this->task('taskExec', $command)->run();
+        return $this->task(Exec::class, $command)->run();
     }
 }


### PR DESCRIPTION
Any RoboFile using the _exec() shortcut is broken it seems.

E.g.
```
$  robo build
Class taskExec does not exist
```