### PR TITLE
Always escape arguments CommandArguments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 * Use league/container to do Dependency Injection
    * *Breaking* Tasks' loadTasks traits must use `$this->task(TaskClass::class);` instead of `new TaskClass();`
    * *Breaking* Tasks that use other tasks must use `$this->collectionBuilder()->taskName();` instead of `new TaskClass();` when creating task objects to call. Implement `Robo\Contract\BuilderAwareInterface` and use `Robo\Contract\BuilderAwareTrait` to add the `collectionBuilder()` method to your task class.
-* *Breaking* The `arg()`, `args()` and `option()` methods now escape the values passed in to them.
+* *Breaking* The `arg()`, `args()` and `option()` methods in CommandArguments now escape the values passed in to them. There is now a `rawArg()` method if you need to add just one argument that has already been escaped.
 * *Breaking* taskWrite is now called taskWriteToFile
 * [Extract] task added
 * [Pack] task added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 * Use league/container to do Dependency Injection
    * *Breaking* Tasks' loadTasks traits must use `$this->task(TaskClass::class);` instead of `new TaskClass();`
    * *Breaking* Tasks that use other tasks must use `$this->collectionBuilder()->taskName();` instead of `new TaskClass();` when creating task objects to call. Implement `Robo\Contract\BuilderAwareInterface` and use `Robo\Contract\BuilderAwareTrait` to add the `collectionBuilder()` method to your task class.
+* *Breaking* The `arg()`, `args()` and `option()` methods now escape the values passed in to them.
+* *Breaking* taskWrite is now called taskWriteToFile
 * [Extract] task added
 * [Pack] task added
 * [TmpDir], [WorkDir] and [TmpFile] tasks added
@@ -30,7 +32,6 @@
 * Add `robo generate:task` code-generator to make new stack-based task wrappers around existing classes
 * Add `robo sniff` by @dustinleblanc. Runs the PHP code sniffer followed by the code beautifier, if needed.
 * Implement ArrayInterface for Result class, so result data may be accessed like an array 
-* *Breaking* taskWrite is now called taskWriteToFile
 * Defer execution of operations in taskWriteToFile until the run() method
 * Add Write::textIfMatch() for taskWriteToFile
 * ResourceExistenceChecker used for error checking in DeleteDir, CopyDir, CleanDir and Concat tasks by @burzum

--- a/src/Task/Remote/Rsync.php
+++ b/src/Task/Remote/Rsync.php
@@ -315,8 +315,8 @@ class Rsync extends BaseTask implements CommandInterface
      */
     public function getCommand()
     {
-        $this->option(null, escapeshellarg($this->getFromPathSpec()))
-            ->option(null, escapeshellarg($this->getToPathSpec()));
+        $this->option(null, $this->getFromPathSpec())
+            ->option(null, $this->getToPathSpec());
 
         return $this->command . $this->arguments;
     }

--- a/tests/unit/Task/ApiGenTest.php
+++ b/tests/unit/Task/ApiGenTest.php
@@ -43,7 +43,7 @@ class ApiGenTest extends \Codeception\TestCase\Test
             ->tree('Y') // boolean as string
             ->debug('n');
 
-        $cmd = 'apigen --config ./apigen.neon --source src --extensions php --exclude test --exclude tmp --skip-doc-path a --skip-doc-path b --charset utf8,iso88591 --internal no --php yes --tree yes --debug no';
+        $cmd = 'apigen --config ./apigen.neon --source src --extensions php --exclude test --exclude tmp --skip-doc-path a --skip-doc-path b --charset \'utf8,iso88591\' --internal no --php yes --tree yes --debug no';
         verify($task->getCommand())->equals($cmd);
 
         $task->run();

--- a/tests/unit/Task/RsyncTest.php
+++ b/tests/unit/Task/RsyncTest.php
@@ -29,14 +29,7 @@ class RsyncTest extends \Codeception\TestCase\Test
                 ->stats()
                 ->getCommand()
         )->equals(
-            sprintf(
-                'rsync --recursive --exclude %s --exclude %s --exclude %s --checksum --whole-file --verbose --progress --human-readable --stats %s %s',
-                escapeshellarg('.git'),
-                escapeshellarg('.svn'),
-                escapeshellarg('.hg'),
-                escapeshellarg('src/'),
-                escapeshellarg('dev@localhost:/var/www/html/app/')
-            )
+                'rsync --recursive --exclude .git --exclude .svn --exclude .hg --checksum --whole-file --verbose --progress --human-readable --stats src/ \'dev@localhost:/var/www/html/app/\''
         );
 
         verify(
@@ -47,11 +40,7 @@ class RsyncTest extends \Codeception\TestCase\Test
                 ->toPath('/var/path/with/a space')
                 ->getCommand()
         )->equals(
-            sprintf(
-                'rsync %s %s',
-                escapeshellarg('src/foo bar/baz'),
-                escapeshellarg('dev@localhost:/var/path/with/a space')
-            )
+                'rsync \'src/foo bar/baz\' \'dev@localhost:/var/path/with/a space\''
         );
     }
 }


### PR DESCRIPTION
One more change, for consistency.

Arguments passed to `->arg()` and values passed to `->option()` are always escaped. This is better and safer, and makes option() and optionList() consistent. `->rawArg()` is available for clients that have a value that has already been shell-escaped.

Note that entire command strings, e.g. those passed to the constructor of Exec(), are expected to be already escaped by the client.