### PR TITLE
Protect BuilderAwareTrait::collectionBuilder() 

### DIFF
--- a/src/Common/BuilderAwareTrait.php
+++ b/src/Common/BuilderAwareTrait.php
@@ -33,7 +33,7 @@ trait BuilderAwareTrait
     /**
      * @inheritdoc
      */
-    public function collectionBuilder()
+    protected function collectionBuilder()
     {
         return $this->getBuilder()->newBuilder();
     }

--- a/src/Contract/BuilderAwareInterface.php
+++ b/src/Contract/BuilderAwareInterface.php
@@ -19,11 +19,4 @@ interface BuilderAwareInterface
      * @return \Robo\Collection\CollectionBuilder
      */
     public function getBuilder();
-
-    /**
-     * Create a new collection builder object
-     *
-     * @return \Robo\Collection\CollectionBuilder
-     */
-    public function collectionBuilder();
 }


### PR DESCRIPTION
so that it does not appear as a command in RoboFiles.

Simple bugfix.