### PR TITLE
Add a test for Result::$stopOnFail.

### DIFF
--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -8,6 +8,7 @@ use Robo\Task\StackBasedTask;
 use Robo\Task\BaseTask;
 use Robo\TaskInfo;
 use Robo\Contract\WrappedTaskInterface;
+use Robo\Exception\TaskExitException;
 
 use Robo\Contract\ProgressIndicatorAwareInterface;
 use Robo\Common\ProgressIndicatorAwareTrait;
@@ -467,6 +468,9 @@ class Collection extends BaseTask implements CollectionInterface
                 $key = static::isUnnamedTask($taskName) ? $name : $taskName;
                 $result = $this->accumulateResults($key, $result, $taskResult);
             }
+        } catch (TaskExitException $exitException) {
+            $this->fail();
+            throw $exitException;
         } catch (\Exception $e) {
             // Tasks typically should not throw, but if one does, we will
             // convert it into an error and roll back.

--- a/src/Exception/TaskExitException.php
+++ b/src/Exception/TaskExitException.php
@@ -1,0 +1,13 @@
+<?php
+namespace Robo\Exception;
+
+class TaskExitException extends \Exception
+{
+    public function __construct($class, $message, $status)
+    {
+        if (is_object($class)) {
+            $class = get_class($class);
+        }
+        parent::__construct("  in task $class \n\n  $message", $status);
+    }
+}

--- a/src/Result.php
+++ b/src/Result.php
@@ -3,6 +3,7 @@ namespace Robo;
 
 use Robo\Contract\TaskInterface;
 use Robo\Contract\LogResultInterface;
+use Robo\Exception\TaskExitException;
 
 class Result extends ResultData
 {
@@ -116,8 +117,13 @@ class Result extends ResultData
             if ($resultPrinter) {
                 $resultPrinter->printStopOnFail($this);
             }
-            exit($this->exitCode);
+            $this->exitEarly($this->getExitCode());
         }
         return $this;
+    }
+
+    private function exitEarly($status)
+    {
+        throw new TaskExitException($this->getTask(), $this->getMessage(), $status);
     }
 }

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -8,6 +8,7 @@ use Symfony\Component\Console\Input\StringInput;
 use Consolidation\AnnotatedCommand\PassThroughArgsInput;
 use Robo\Contract\BuilderAwareInterface;
 use Robo\Common\IO;
+use Robo\Exception\TaskExitException;
 
 class Runner
 {
@@ -102,7 +103,11 @@ class Runner
         $this->setInput($input);
         $this->setOutput($output);
 
-        $statusCode = $app->run($input, $output);
+        try {
+            $statusCode = $app->run($input, $output);
+        } catch (TaskExitException $e) {
+            $statusCode = $e->getCode() ?: 1;
+        }
         return $statusCode;
     }
 

--- a/tests/_helpers/CodeHelper.php
+++ b/tests/_helpers/CodeHelper.php
@@ -24,6 +24,11 @@ class CodeHelper extends \Codeception\Module
 
     public function _after(\Codeception\TestCase $test)
     {
+        // Ensure that $stopOnFail global static is reset, as tests
+        // that set it to true will force an exception, and therefor
+        // will not have a chance to clean this up.
+        \Robo\Result::$stopOnFail = false;
+
         \AspectMock\Test::clean();
         $consoleOutput = new ConsoleOutput();
         static::$container->add('output', $consoleOutput);

--- a/tests/src/TestRoboFile.php
+++ b/tests/src/TestRoboFile.php
@@ -43,4 +43,18 @@ class TestRoboFile extends \Robo\Tasks
         }
         throw new \RuntimeException('Task failed with an exception.');
     }
+
+    public function testStopOnFail()
+    {
+        $this->stopOnFail();
+        $this->collectionBuilder()
+            ->taskExec('ls xyzzy' . date('U'))
+                ->dir('/tmp')
+            ->run();
+
+        // stopOnFail() should cause the failed task to throw an exception,
+        // so we should not get here, and instead exit the program with a
+        // non-zero status.
+        return 0;
+    }
 }

--- a/tests/unit/ResultTest.php
+++ b/tests/unit/ResultTest.php
@@ -1,5 +1,6 @@
 <?php
 use Robo\Result;
+use Robo\Exception\TaskExitException;
 
 class ResultTest extends \Codeception\TestCase\Test {
 
@@ -34,6 +35,39 @@ class ResultTest extends \Codeception\TestCase\Test {
         $task = new ResultDummyTask();
         $result = new Result($task, 1, 'The foo barred', ['time' => 10]);
         $this->assertEquals($result['time'], 10);
+    }
+
+    public function testStopOnFail()
+    {
+        $exceptionClass = false;
+        $task = new ResultDummyTask();
+
+        Result::$stopOnFail = true;
+        $result = Result::success($task, "Something that worked");
+        try {
+            $result = Result::error($task, "Something that did not work");
+            // stopOnFail will cause Result::error() to throw an exception,
+            // so we will never get here. If we did, the assert below would fail.
+            $this->assertTrue($result->wasSuccessful());
+            $this->assertTrue(false);
+        } catch (\Exception $e) {
+            $exceptionClass = get_class($e);
+        }
+        $this->assertEquals(TaskExitException::class, $exceptionClass);
+        $this->assertTrue($result->wasSuccessful());
+
+        /*
+        // This gives an error:
+        //    Exception of class Robo\Exception\TaskExitException expected to
+        //    be thrown, but PHPUnit_Framework_Exception caught
+        // This happens whether or not the expected exception is thrown
+        $this->guy->expectException(TaskExitException::class, function() {
+            // $result = Result::error($task, "Something that did not work");
+            $result = Result::success($task, "Something that worked");
+        });
+        */
+
+        Result::$stopOnFail = false;
     }
 }
 

--- a/tests/unit/RunnerTest.php
+++ b/tests/unit/RunnerTest.php
@@ -138,4 +138,13 @@ EOT;
         unlink('testRoboFile');
         $this->assertContains('class RoboTestClass', $commandContents);
     }
+
+    public function testTasksStopOnFail()
+    {
+        $argv = ['placeholder', 'test:stop-on-fail'];
+        $result = $this->runner->execute($argv, Robo::output());
+
+        $this->guy->seeInOutput('[');
+        $this->assertTrue($result > 0);
+    }
 }


### PR DESCRIPTION
Make stop on fail throw an exception, so that it will be testable. Make stopOnFail and collections interact better - stop on fail can be used to interrupt a collection, which will still clean up on failure, and stop execution of further code.