### PR TITLE
Add accessor for SymfonyStyle object.

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -316,6 +316,12 @@ $name = $this->ask("What is your name?");
 
 There are also `askDefault`, `askHidden`, and `confirm` methods.
 
+In addition, Robo makes all of the methods of Symfony Style available throgh the `io()` method:
+
+$this->io()->title("Build all site assets");
+
+This allows Robo scripts to follow the [Symfony Console Style Guide](http://symfony.com/blog/new-in-symfony-2-8-console-style-guide) if desired.
+
 ### Formatters
 
 It is preferable for commands that look up and display information should avoid doing IO directly, and should instead return the data they wish to display as an array. This data can then be converted into different data formats, such as "table" and "json". The user may select which formatter to use via the --format option. For details on formatters, see the [consolidation/output-formatters](https://github.com/consolidation-org/output-formatters) project.

--- a/src/Common/IO.php
+++ b/src/Common/IO.php
@@ -9,11 +9,28 @@ use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 trait IO
 {
     use InputAwareTrait;
     use OutputAwareTrait;
+
+    /** var: SymfonyStyle */
+    protected $io;
+
+    /**
+     * Provide access to SymfonyStyle object.
+     * See: http://symfony.com/blog/new-in-symfony-2-8-console-style-guide
+     * @return SymfonyStyle
+     */
+    protected function io()
+    {
+        if (!$this->io) {
+            $this->io = new SymfonyStyle($this->input(), $this->output());
+        }
+        return $this->io;
+    }
 
     protected function decorationCharacter($nonDecorated, $decorated)
     {

--- a/tests/src/TestRoboFile.php
+++ b/tests/src/TestRoboFile.php
@@ -24,6 +24,19 @@ class TestRoboFile extends \Robo\Tasks
     }
 
     /**
+     * Demonstrate use of SymfonyStyle
+     */
+    public function testSymfonyStyle()
+    {
+        $this->io()->title('My Title');
+        $this->io()->section('Section 1');
+        $this->io()->text('Some text in section one.');
+        $this->io()->comment('This is just an example of different styles.');
+        $this->io()->section('Section 2');
+        $this->io()->text('Some text in section two.');
+    }
+
+    /**
      * Demonstrate Robo error output and command failure.
      */
     public function testError()

--- a/tests/unit/RunnerTest.php
+++ b/tests/unit/RunnerTest.php
@@ -106,6 +106,13 @@ EOT;
         $this->guy->seeOutputEquals($expected);
     }
 
+    public function testSymfonyStyle()
+    {
+        $argv = ['placeholder', 'test:symfony-style'];
+        $this->runner->execute($argv, Robo::output());
+        $this->guy->seeInOutput('Some text in section one.');
+    }
+
     public function testRunnerTryError()
     {
         $argv = ['placeholder', 'test:error'];


### PR DESCRIPTION
The SymfonyStyle class is very popular; see the [introductory documentation](http://symfony.com/blog/new-in-symfony-2-8-console-style-guide) for details.

This is how folks expect to do IO with Symfony Console applications nowadays, so we should provide ready access to it from RoboFiles.  It might even be a good idea to update the documentation to use SymfonyStyle for IO.

The existing methods in the IO trait may remain for backwards compatibility with Robo 0.x; perhaps these should be deprecated and removed in 2.x.
