### PR TITLE
Fixes #442: Pass a collection to Remote\Ssh

### DIFF
--- a/src/Collection/CollectionBuilder.php
+++ b/src/Collection/CollectionBuilder.php
@@ -17,6 +17,8 @@ use Robo\Common\ConfigAwareTrait;
 use ReflectionClass;
 use Robo\Task\BaseTask;
 use Robo\Contract\BuilderAwareInterface;
+use Robo\Contract\CommandInterface;
+use Robo\Exception\TaskException;
 
 /**
  * Creates a collection, and adds tasks to it.  The collection builder
@@ -45,7 +47,7 @@ use Robo\Contract\BuilderAwareInterface;
  * In the example above, the `taskDeleteDir` will be called if
  * ```
  */
-class CollectionBuilder extends BaseTask implements NestedCollectionInterface, WrappedTaskInterface
+class CollectionBuilder extends BaseTask implements NestedCollectionInterface, WrappedTaskInterface, CommandInterface
 {
     protected $commandFile;
     protected $collection;
@@ -352,6 +354,19 @@ class CollectionBuilder extends BaseTask implements NestedCollectionInterface, W
             return $this->currentTask->run();
         }
         return $this->getCollection()->run();
+    }
+
+    public function getCommand()
+    {
+        if (!$this->collection && $this->currentTask) {
+            $task = $this->currentTask;
+            $task = ($task instanceof WrappedTaskInterface) ? $task->original() : $task;
+            if ($task instanceof CommandInterface) {
+                return $task->getCommand();
+            }
+        }
+
+        return $this->getCollection()->getCommand();
     }
 
     public function original()

--- a/src/Collection/Element.php
+++ b/src/Collection/Element.php
@@ -3,6 +3,8 @@
 namespace Robo\Collection;
 
 use Robo\Contract\TaskInterface;
+use Robo\Contract\WrappedTaskInterface;
+use Robo\Contract\ProgressIndicatorAwareInterface;
 
 /**
  * One element in a collection.  Each element consists of a task
@@ -57,5 +59,24 @@ class Element
     public function getTaskList()
     {
         return array_merge($this->getBefore(), [$this->getTask()], $this->getAfter());
+    }
+
+    public function progressIndicatorSteps()
+    {
+        $steps = 0;
+        foreach ($this->getTaskList() as $task) {
+            if ($task instanceof WrappedTaskInterface) {
+                $task = $task->original();
+            }
+            // If the task is a ProgressIndicatorAwareInterface, then it
+            // will advance the progress indicator a number of times.
+            if ($task instanceof ProgressIndicatorAwareInterface) {
+                $steps += $task->progressIndicatorSteps();
+            }
+            // We also advance the progress indicator once regardless
+            // of whether it is progress-indicator aware or not.
+            $steps++;
+        }
+        return $steps;
     }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -21,7 +21,7 @@ class Config
         return $this;
     }
 
-    public function setGlobalOptions($input)
+    public function getGlobalOptionDefaultValues()
     {
         $globalOptions =
         [
@@ -29,6 +29,13 @@ class Config
             self::SIMULATE => false,
             self::SUPRESS_MESSAGES => false,
         ];
+
+        return $globalOptions;
+    }
+
+    public function setGlobalOptions($input)
+    {
+        $globalOptions = $this->getGlobalOptionDefaultValues();
 
         foreach ($globalOptions as $option => $default) {
             $value = $input->hasOption($option) ? $input->getOption($option) : null;

--- a/src/Result.php
+++ b/src/Result.php
@@ -88,6 +88,39 @@ class Result extends ResultData
     }
 
     /**
+     * Add the results from the most recent task to the accumulated
+     * results from all tasks that have run so far, merging data
+     * as necessary.
+     */
+    public function accumulate($key, Result $taskResult)
+    {
+        // If the task is unnamed, then all of its data elements
+        // just get merged in at the top-level of the final Result object.
+        if (static::isUnnamed($key)) {
+            $this->merge($taskResult);
+        } elseif (isset($this[$key])) {
+            // There can only be one task with a given name; however, if
+            // there are tasks added 'before' or 'after' the named task,
+            // then the results from these will be stored under the same
+            // name unless they are given a name of their own when added.
+            $current = $this[$key];
+            $this[$key] = $taskResult->merge($current);
+        } else {
+            $this[$key] = $taskResult;
+        }
+    }
+
+    /**
+     * We assume that named values (e.g. for associative array keys)
+     * are non-numeric; numeric keys are presumed to simply be the
+     * index of an array, and therefore insignificant.
+     */
+    public static function isUnnamed($key)
+    {
+        return is_numeric($key);
+    }
+
+    /**
      * @return TaskInterface
      */
     public function getTask()

--- a/src/Robo.php
+++ b/src/Robo.php
@@ -47,7 +47,7 @@ class Robo
     /**
      * Returns the currently active global container.
      *
-     * @return \League\Container\ContainerInterface|null
+     * @return \League\Container\ContainerInterface
      *
      * @throws \RuntimeException
      */
@@ -74,10 +74,14 @@ class Robo
      */
     public static function createDefaultContainer($input = null, $output = null, $app)
     {
+        // Do not allow this function to be called more than once.
+        if (static::hasContainer()) {
+            return static::getContainer();
+        }
+
         // Set up our dependency injection container.
         $container = new Container();
         static::configureContainer($container, $input, $output, $app);
-        static::setContainer($container);
 
         return $container;
     }
@@ -89,6 +93,7 @@ class Robo
     {
         // Self-referential container refernce for the inflector
         $container->add('container', $container);
+        static::setContainer($container);
 
         // Create default input and output objects if they were not provided
         if (!$input) {

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -89,8 +89,11 @@ class Runner implements ContainerAwareInterface
     {
         $argv = $this->shebang($argv);
         $argv = $this->processRoboOptions($argv);
-        $app = Robo::createDefaultApplication($appName, $appVersion);
-        $commandFiles = $this->getRoboFileCommands($app, $output);
+        $app = null;
+        if ($appName && $appVersion) {
+            $app = Robo::createDefaultApplication($appName, $appVersion);
+        }
+        $commandFiles = $this->getRoboFileCommands($output);
         return $this->run($argv, $output, $app, $commandFiles);
     }
 
@@ -140,7 +143,7 @@ class Runner implements ContainerAwareInterface
         return $statusCode;
     }
 
-    protected function getRoboFileCommands($app, $output)
+    protected function getRoboFileCommands($output)
     {
         if (!$this->loadRoboFile($output)) {
             return;

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -112,19 +112,15 @@ class Runner implements ContainerAwareInterface
         $this->setInput($input);
         $this->setOutput($output);
 
-        // If our client gave us a container, then also set it inside
-        // the static Robo class.
-        if ($this->getContainer()) {
-            Robo::setContainer($this->getContainer());
-        }
         // If we were not provided a container, then create one
-        if (!Robo::hasContainer()) {
-            Robo::createDefaultContainer($input, $output, $app);
-            $this->setContainer(Robo::getContainer());
+        if (!$this->getContainer()) {
+            $container = Robo::createDefaultContainer($input, $output, $app);
+            $this->setContainer($container);
             // Automatically register a shutdown function and
             // an error handler when we provide the container.
             $this->installRoboHandlers();
         }
+
         if (!$app) {
             $app = Robo::application();
         }

--- a/src/Task/Remote/Ssh.php
+++ b/src/Task/Remote/Ssh.php
@@ -6,6 +6,7 @@ use Robo\Result;
 use Robo\Contract\CommandInterface;
 use Robo\Exception\TaskException;
 use Robo\Task\BaseTask;
+use Robo\Contract\SimulatedInterface;
 
 /**
  * Runs multiple commands on a remote server.
@@ -45,7 +46,7 @@ use Robo\Task\BaseTask;
  *                                            and stop the chain if one command fails
  * @method $this remoteDir(string $remoteWorkingDirectory) Changes to the given directory before running commands
  */
-class Ssh extends BaseTask implements CommandInterface
+class Ssh extends BaseTask implements CommandInterface, SimulatedInterface
 {
     use \Robo\Common\CommandReceiver;
     use \Robo\Common\ExecOneCommand;
@@ -175,6 +176,12 @@ class Ssh extends BaseTask implements CommandInterface
         $this->validateParameters();
         $command = $this->getCommand();
         return $this->executeCommand($command);
+    }
+
+    public function simulate($context)
+    {
+        $command = $this->getCommand();
+        $this->printTaskInfo("Running {command}", ['command' => $command] + $context);
     }
 
     protected function validateParameters()

--- a/src/Task/Testing/PHPUnit.php
+++ b/src/Task/Testing/PHPUnit.php
@@ -131,7 +131,8 @@ class PHPUnit extends BaseTask implements CommandInterface, PrintedInterface
      * @param string $file path to file to test
      * @return $this
      */
-    public function file($file) {
+    public function file($file)
+    {
         return $this->files($file);
     }
 
@@ -140,7 +141,8 @@ class PHPUnit extends BaseTask implements CommandInterface, PrintedInterface
      * @param string $dir path to directory to test
      * @return $this
      */
-    public function dir($dir) {
+    public function dir($dir)
+    {
         return $this->dir($dir);
     }
 

--- a/tests/src/RoboFileFixture.php
+++ b/tests/src/RoboFileFixture.php
@@ -88,4 +88,15 @@ class RoboFileFixture extends \Robo\Tasks implements LoggerAwareInterface
         $this->logger->notice('This is a notice log message.');
         $this->logger->debug('This is a debug log message.');
     }
+
+    public function testDeploy()
+    {
+        $gitTask = $this->taskGitStack()
+            ->pull();
+
+        $this->taskSshExec('mysite.com')
+            ->remoteDir('/var/www/somesite')
+            ->exec($gitTask)
+            ->run();
+    }
 }

--- a/tests/unit/RunnerTest.php
+++ b/tests/unit/RunnerTest.php
@@ -113,6 +113,14 @@ EOT;
         $this->guy->seeInOutput('Some text in section one.');
     }
 
+    public function testDeploy()
+    {
+        $argv = ['placeholder', 'test:deploy', '--simulate'];
+        $this->runner->execute($argv, $this->guy->capturedOutputStream());
+        $this->guy->seeInOutput('[Simulator] Simulating Remote\\Ssh(\'mysite.com\', null)');
+        $this->guy->seeInOutput('[Simulator] Running ssh mysite.com \'cd "/var/www/somesite" && git pull\'');
+    }
+
     public function testRunnerTryError()
     {
         $argv = ['placeholder', 'test:error'];
@@ -120,6 +128,15 @@ EOT;
 
         $this->guy->seeInOutput('[Exec] Running ls xyzzy');
         $this->assertTrue($result > 0);
+    }
+
+    public function testRunnerTrySimulatedError()
+    {
+        $argv = ['placeholder', 'test:error', '--simulate'];
+        $result = $this->runner->execute($argv, $this->guy->capturedOutputStream());
+
+        $this->guy->seeInOutput('Simulating Exec');
+        $this->assertEquals(0, $result);
     }
 
     public function testRunnerTryException()


### PR DESCRIPTION
Allow CollectionBuilder, Collection and Simulated tasks to be used by tasks (e.g. Remote\Ssh) that require a CommandInterface.